### PR TITLE
adds listener for marker/cluster

### DIFF
--- a/library/src/main/java/io/nlopez/clusterer/Clusterer.java
+++ b/library/src/main/java/io/nlopez/clusterer/Clusterer.java
@@ -124,10 +124,14 @@ public class Clusterer<T extends Clusterable> {
             if (cluster != null) {
                 CameraUpdate update = CameraUpdateFactory.newLatLngBounds(cluster.getBounds(), CLUSTER_CENTER_PADDING);
                 googleMap.animateCamera(update, CAMERA_ANIMATION_DURATION, null);
-                listener.clusterClicked(cluster);
+                if (clustererClickListener != null) {
+                    clustererClickListener.clusterClicked(cluster);
+                }
                 return true;
             }
-            listener.markerClicked(getClusterableFromMarker(marker));
+            if (clustererClickListener != null) {
+                clustererClickListener.markerClicked(getClusterableFromMarker(marker));
+            }
             return false;
         }
     };

--- a/library/src/main/java/io/nlopez/clusterer/Clusterer.java
+++ b/library/src/main/java/io/nlopez/clusterer/Clusterer.java
@@ -107,6 +107,16 @@ public class Clusterer<T extends Clusterable> {
         }
     };
 
+    private Listener listener;
+
+    public Listener getListener() {
+        return listener;
+    }
+
+    public void setClustererListener(Listener listener) {
+        this.listener = listener;
+    }
+
     GoogleMap.OnMarkerClickListener markerClicked = new GoogleMap.OnMarkerClickListener() {
         @Override
         public boolean onMarkerClick(Marker marker) {
@@ -114,8 +124,10 @@ public class Clusterer<T extends Clusterable> {
             if (cluster != null) {
                 CameraUpdate update = CameraUpdateFactory.newLatLngBounds(cluster.getBounds(), CLUSTER_CENTER_PADDING);
                 googleMap.animateCamera(update, CAMERA_ANIMATION_DURATION, null);
+                listener.clusterClicked(cluster);
                 return true;
             }
+            listener.markerClicked(getClusterableFromMarker(marker));
             return false;
         }
     };
@@ -480,6 +492,13 @@ public class Clusterer<T extends Clusterable> {
 
     public interface OnCameraChangeListener {
         void onCameraChange(CameraPosition position);
+    }
+
+    public interface Listener<T extends Clusterable> {
+
+        void markerClicked(T marker);
+
+        void clusterClicked(Cluster position);
     }
 
 }

--- a/library/src/main/java/io/nlopez/clusterer/Clusterer.java
+++ b/library/src/main/java/io/nlopez/clusterer/Clusterer.java
@@ -107,14 +107,14 @@ public class Clusterer<T extends Clusterable> {
         }
     };
 
-    private Listener listener;
+    private ClustererClickListener clustererClickListener;
 
-    public Listener getListener() {
-        return listener;
+    public ClustererClickListener getClustererClickListener() {
+        return clustererClickListener;
     }
 
-    public void setClustererListener(Listener listener) {
-        this.listener = listener;
+    public void setClustererListener(ClustererClickListener clustererClickListener) {
+        this.clustererClickListener = clustererClickListener;
     }
 
     GoogleMap.OnMarkerClickListener markerClicked = new GoogleMap.OnMarkerClickListener() {
@@ -494,7 +494,7 @@ public class Clusterer<T extends Clusterable> {
         void onCameraChange(CameraPosition position);
     }
 
-    public interface Listener<T extends Clusterable> {
+    public interface ClustererClickListener<T extends Clusterable> {
 
         void markerClicked(T marker);
 

--- a/sample/src/main/java/io/nlopez/clusterer/sample/application/MainActivity.java
+++ b/sample/src/main/java/io/nlopez/clusterer/sample/application/MainActivity.java
@@ -104,7 +104,7 @@ public class MainActivity extends Activity {
             }
         });
 
-        clusterer.setClustererListener(new Clusterer.Listener<PointOfInterest>() {
+        clusterer.setClustererListener(new Clusterer.ClustererClickListener<PointOfInterest>() {
             @Override
             public void markerClicked(PointOfInterest marker) {
                 Log.e("Clusterer", "marker clicked");

--- a/sample/src/main/java/io/nlopez/clusterer/sample/application/MainActivity.java
+++ b/sample/src/main/java/io/nlopez/clusterer/sample/application/MainActivity.java
@@ -10,6 +10,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.os.Bundle;
+import android.util.Log;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
@@ -100,6 +101,18 @@ public class MainActivity extends Activity {
             public void animateMarker(Marker marker, float interpolation) {
                 // Basic fading animation
                 marker.setAlpha(interpolation);
+            }
+        });
+
+        clusterer.setClustererListener(new Clusterer.Listener<PointOfInterest>() {
+            @Override
+            public void markerClicked(PointOfInterest marker) {
+                Log.e("Clusterer", "marker clicked");
+            }
+
+            @Override
+            public void clusterClicked(Cluster position) {
+                Log.e("Clusterer", "cluster clicked");
             }
         });
 


### PR DESCRIPTION
This PR fixes issue #11 adding listeners for cluster and marker. 
When a marker is clicked the corresponding object is sent. When a cluster is clicked, its position is sent.

![image](http://media.giphy.com/media/APd3yd2DpnCH6/giphy.gif)
